### PR TITLE
Make the light themes match the Pop Theme

### DIFF
--- a/poptheme/themes/Pop-Light-color-theme.json
+++ b/poptheme/themes/Pop-Light-color-theme.json
@@ -2,201 +2,201 @@
     "name": "Pop Light",
     "type": "light",
     "colors": {
+        // Base
+        // "foreground": "",
+		"focusBorder": "#574F4A",
+        // "contrastActiveBorder": "",
+        // "contrastBorder": "",
 
-                // Base
-                // "foreground": "",
-                "focusBorder": "#574e4a",
-                // "contrastActiveBorder": "",
-                // "contrastBorder": "",
-        
-                // "widget.shadow": "",
-				"textLink.foreground": "#48b9c7",
-                "input.background": "#bbb5b3",
-                // "input.border": "",
-                "input.foreground": "#574e4a",
-                "input.placeholderForeground": "#574e4aAA",
-                "inputOption.activeBorder": "#574e4a",
-                // "inputValidation.infoBorder": "",
-                // "inputValidation.infoBackground": "",
-                // "inputValidation.warningBackground": "",
-                // "inputValidation.warningBorder": "",
-                // "inputValidation.errorBackground": "",
-                // "inputValidation.errorBorder": "",
-        
-                "badge.background": "#48b9c7",
-                "progressBar.background": "#faa41a",
-        
-                "dropdown.background": "#73c48f",
-                // "dropdown.foreground": "",
-                "dropdown.border": "#63524b00",
-        
-                "button.background": "#48b9c7",
-                // "button.foreground": "",
-        
-                "selection.background": "#CCC4B0",
-        
-                "list.activeSelectionBackground": "#faa41a",
-                "list.activeSelectionForeground": "#ffffff",
-				"list.focusBackground": "#48b9c7",
-				"list.focusForeground": "#574e4a",
-                "list.hoverBackground": "#c7c7c6",
-                "list.inactiveSelectionBackground": "#c7c7c6",
-                "list.highlightForeground": "#faa41a",
-        
-                // "scrollbar.shadow": "",
-                // "scrollbarSlider.activeBackground": "",
-                // "scrollbarSlider.background": "",
-                // "scrollbarSlider.hoverBackground": "",
+        // "widget.shadow": "",
+         "textLink.foreground": "#C26C00",
+         "textLink.activeForeground": "#DE8800",
+         "input.background": "#FFFFFF",
+         "input.border": "#0008",
+         "input.foreground": "#403C3A",
+         "input.placeholderForeground": "#403C3A88",
+         "inputOption.activeBorder": "#FAA41A",
+        // "inputValidation.infoBorder": "",
+        // "inputValidation.infoBackground": "",
+        // "inputValidation.warningBackground": "",
+        // "inputValidation.warningBorder": "",
+        // "inputValidation.errorBackground": "",
+        // "inputValidation.errorBorder": "",
 
-				
-				
-                // Editor
-                "editor.background": "#f7f7f7",
-                // "editor.foreground": "#6688cc",
-                "editorWidget.background": "#d3d0d0",
-                "editorCursor.foreground": "#657B83",
-                "editorWhitespace.foreground": "#a58e6454",
-                "editor.lineHighlightBackground": "#d3d0d0",
-                "editor.selectionBackground": "#d3d0d0",
-                // "editorIndentGuide.background": "",
-                "editorHoverWidget.background": "#d3d0d0",
-                // "editorHoverWidget.border": "",
-                "editorLineNumber.foreground": "#35a6b3",
-                // "editorMarkerNavigation.background": "",
-                // "editorMarkerNavigationError.background": "",
-                // "editorMarkerNavigationWarning.background": "",
-                // "editorLink.activeForeground": "",
-                // "editor.findMatchBackground": "",
-                // "editor.findMatchHighlightBackground": "",
-                // "editor.findRangeHighlightBackground": "",
-                // "editor.hoverHighlightBackground": "",
-                // "editor.inactiveSelectionBackground": "",
-                // "editor.lineHighlightBorder": "",
-                // "editor.rangeHighlightBackground": "",
-                // "editor.selectionHighlightBackground": "",
-                // "editor.wordHighlightBackground": "",
-                // "editor.wordHighlightStrongBackground": "",
+         "badge.background": "#F15D22",
+         "progressBar.background": "#48B9C7",
+
+         "dropdown.background": "#F6F6F6",
+         "dropdown.foreground": "#403C3A",
+         "dropdown.border": "#63524b00",
+
+         "button.background": "#F6F6F6",
+        // "button.foreground": "",
+
+         "selection.background": "#1C8D9B",
+
+         "list.activeSelectionBackground": "#574F4A33",
+         "list.activeSelectionForeground": "#403C3A",
+         "list.focusBackground": "#48B9C7",
+         "list.focusForeground": "#FCFCFC",
+         "list.hoverBackground": "#FCFCFC44",
+         "list.inactiveSelectionBackground": "#48B9C7AA",
+         "list.highlightForeground": "#FAA41A",
+
+        // "scrollbar.shadow": "",
+        // "scrollbarSlider.activeBackground": "",
+        // "scrollbarSlider.background": "",
+        // "scrollbarSlider.hoverBackground": "",
+
         
-                // Editor: Suggest Widget
-                // "editorSuggestWidget.background": "",
-                // "editorSuggestWidget.border": "",
-                // "editorSuggestWidget.foreground": "",
-                // "editorSuggestWidget.highlightForeground": "",
-                // "editorSuggestWidget.selectedBackground": "",
         
-                // Editor: Peek View
-                "peekViewResult.background": "#d3d0d0",
-                // "peekViewResult.lineForeground": "",
-                // "peekViewResult.selectionBackground": "",
-                // "peekViewResult.selectionForeground": "",
-                "peekViewEditor.background": "#FFFBF2",
-                "peekViewTitle.background": "#d3d0d0",
-                "peekView.border": "#faa41a",
-                "peekViewEditor.matchHighlightBackground": "#7744AA40",
-                // "peekViewResult.fileForeground": "",
-                // "peekViewResult.matchHighlightBackground": "",
-                // "peekViewTitleLabel.foreground": "",
-                // "peekViewTitleDescription.foreground": "",
-        
-                // Editor: Diff
-                // "diffEditor.insertedTextBackground": "",
-                // "diffEditor.insertedTextBorder": "",
-                // "diffEditor.removedTextBackground": "",
-                // "diffEditor.removedTextBorder": "",
-        
-                // Workbench: Title
-                "titleBar.activeBackground": "#d3d0d0",
-                // "titleBar.activeForeground": "",
-                // "titleBar.inactiveBackground": "",
-                // "titleBar.inactiveForeground": "",
-        
-                // Workbench: Editors
-                // "editorGroupHeader.noTabsBackground": "",
-                "editorGroup.border": "#bbb5b3",
-                "editorGroup.background": "#FFFBF2",
-                "editorGroup.dropBackground": "#bbb5b3AA",
-                "editorGroupHeader.tabsBackground": "#bbb5b3",
-        
-                // Workbench: Tabs
-                "tab.border": "#bbb5b3",
-                "tab.activeBackground": "#48b9c7",
-                "tab.inactiveForeground": "#574e4a",
-                "tab.inactiveBackground": "#00000000",
-                // "tab.activeBackground": "",
-                "tab.activeForeground": "#fffbf2",
-                // "tab.inactiveForeground": "",
-        
-                // Workbench: Activity Bar
-                "activityBar.background": "#4d4643",
-                "activityBar.foreground": "#fdf6e3",
-                "activityBar.dropBackground": "#d3d0d0",
-                "activityBarBadge.background": "#faa41a",
-                "activityBarBadge.foreground": "#4d4643",
-        
-                // Workbench: Panel
-                "panel.background": "#eeeeee",
-                "panel.border": "#bbb5b3",
-                // "panelTitle.activeBorder": "",
-                "panelTitle.activeForeground": "#5c411b",
-                // "panelTitle.inactiveForeground": "",
-        
-                // Workbench: Side Bar
-				"sideBar.background": "#bbb5b3",
-				"sideBar.foreground":"#554741",
-                "sideBarTitle.foreground": "#574e4a",
-				"sideBarSectionHeader.background": "#9d9794",
-				"sideBarSectionHeader.foreground": "#505050",
-        
-                // Workbench: Status Bar
-                "statusBar.foreground": "#fdf6e3",
-                "statusBar.background": "#48b9c7",
-                "statusBar.debuggingBackground": "#d3d0d0",
-                "statusBar.noFolderBackground": "#48b9c7",
-                // "statusBar.foreground": "",
-                "statusBarItem.prominentBackground": "#bbb5b3",
-                "statusBarItem.prominentHoverBackground": "#bbb5b399",
-                // "statusBarItem.activeBackground": "",
-                // "statusBarItem.hoverBackground": "",
-        
-                // Workbench: Debug
-                "debugToolBar.background": "#bbb5b3",
-                "debugExceptionWidget.background": "#bbb5b3",
-                "debugExceptionWidget.border": "#AB395B",
-        
-                // Workbench: Notifications
-				"notification.background": "#bebebe",
-				"notification.infoBackground": "#48b9c7",
-				"notification.infoForeground": "#ffffff",
-				"notification.buttonBackground": "#48b9c7",
-				"notification.warningBackground": "#bebebe",
-                "notification.foreground": "#383838",
-        
-                // Workbench: Quick Open
-                "pickerGroup.border": "#2AA19899",
-                "pickerGroup.foreground": "#2AA19899",
-        
-                // Extensions
-                "extensionButton.prominentBackground": "#faa41a",
-                "extensionButton.prominentHoverBackground": "#584c27aa",
-		
-                // Workbench: Terminal
-        
-                "terminal.ansiBlack": "#073642",
-                "terminal.ansiRed": "#dc322f",
-                "terminal.ansiGreen": "#488d5e",
-                "terminal.ansiYellow": "#faa41a",
-                "terminal.ansiBlue": "#607D8B",
-                "terminal.ansiMagenta": "#f15d22",
-                "terminal.ansiCyan": "#2aa198",
-                "terminal.ansiWhite": "#d3d0d0",
-                "terminal.ansiBrightBlack": "#574e4a",
-                "terminal.ansiBrightRed": "#cb4b16",
-                "terminal.ansiBrightGreen": "#574e4a",
-                "terminal.ansiBrightYellow": "#657b83",
-                "terminal.ansiBrightBlue": "#839496",
-                "terminal.ansiBrightMagenta": "#6c71c4",
-                "terminal.ansiBrightCyan": "#93a1a1",
-                "terminal.ansiBrightWhite": "#d3d0d0"
+        // Editor
+         "editor.background": "#FFF",
+         "editor.foreground": "#403C3A",
+         "editorWidget.background": "#2B2928",
+         "editorCursor.foreground": "#2B2928",
+         "editorWhitespace.foreground": "#DEDEDE11",
+         "editor.lineHighlightBackground": "#EDEDED",
+         "editor.selectionBackground": "#48B9C744",
+         // "editorIndentGuide.background": "",
+        "editorHoverWidget.background": "#F6F6F6",
+        // "editorHoverWidget.border": "",
+        "editorLineNumber.foreground": "#403C3A66",
+        "editorLineNumber.activeForeground": "#403C3A",
+        // "editorMarkerNavigation.background": "",
+        // "editorMarkerNavigationError.background": "",
+        // "editorMarkerNavigationWarning.background": "",
+        // "editorLink.activeForeground": "",
+        // "editor.findMatchBackground": "",
+        // "editor.findMatchHighlightBackground": "",
+        // "editor.findRangeHighlightBackground": "",
+        // "editor.hoverHighlightBackground": "",
+        // "editor.inactiveSelectionBackground": "",
+        // "editor.lineHighlightBorder": "",
+        // "editor.rangeHighlightBackground": "",
+        // "editor.selectionHighlightBackground": "",
+        // "editor.wordHighlightBackground": "",
+        // "editor.wordHighlightStrongBackground": "",
+
+        // Editor: Suggest Widget
+        // "editorSuggestWidget.background": "",
+        // "editorSuggestWidget.border": "",
+        // "editorSuggestWidget.foreground": "",
+        // "editorSuggestWidget.highlightForeground": "",
+        // "editorSuggestWidget.selectedBackground": "",
+
+        // Editor: Peek View
+        "peekViewResult.background": "#EDEDED",
+        // "peekViewResult.lineForeground": "",
+        // "peekViewResult.selectionBackground": "",
+        // "peekViewResult.selectionForeground": "",
+        "peekViewEditor.background": "#EDEDED",
+        "peekViewTitle.background": "#FCFCFC",
+        "peekView.border": "#FAA41A",
+        "peekViewEditor.matchHighlightBackground": "#FFCE5199",
+        // "peekViewResult.fileForeground": "",
+        // "peekViewResult.matchHighlightBackground": "",
+        // "peekViewTitleLabel.foreground": "",
+        // "peekViewTitleDescription.foreground": "",
+
+        // Editor: Diff
+        // "diffEditor.insertedTextBackground": "",
+        // "diffEditor.insertedTextBorder": "",
+        // "diffEditor.removedTextBackground": "",
+        // "diffEditor.removedTextBorder": "",
+
+        // Workbench: Title
+        "titleBar.activeBackground": "#DDD",
+        "titleBar.activeForeground": "#403C3A",
+        "titleBar.inactiveBackground": "#EBEBEB",
+        "titleBar.inactiveForeground": "#403C3AAA",
+
+        // Workbench: Editors
+        "editorGroupHeader.noTabsBackground": "#EDEDED",
+        "editorGroup.border": "#DEDEDE22",
+        "editorGroup.background": "#EDEDED",
+        "editorGroup.dropBackground": "#FAA41AAA",
+        "editorGroupHeader.tabsBackground": "#EDEDED",
+
+        // Workbench: Tabs
+        "tab.border": "#0000",
+        "tab.inactiveForeground": "#403C3A",
+        "tab.inactiveBackground": "#00000000",
+        "tab.activeForeground": "#C26C00",
+        "tab.activeBackground": "#0000",
+        "tab.activeBorder": "#FAA41A",
+
+        // Workbench: Activity Bar
+        "activityBar.background": "#DDD",
+        "activityBar.foreground": "#403C3A",
+        "activityBar.dropBackground": "#d3d0d0",
+        "activityBarBadge.background": "#CF3B00",
+        "activityBarBadge.foreground": "#FFF",
+
+        // Workbench: Panel
+        "panel.background": "#E6E6E6",
+        "panel.border": "#403C3A11",
+        // "panelTitle.activeBorder": "",
+        "panelTitle.activeForeground": "#C26C00",
+        "panelTitle.activeBorder": "#FAA41A",
+        "panelTitle.inactiveForeground": "#403C3A",
+
+        // Workbench: Side Bar
+        "sideBar.background": "#F6F6F6",
+        "sideBar.foreground":"#403C3A",
+        "sideBarTitle.foreground": "#403C3AAA",
+        "sideBarSectionHeader.background": "#DEDEDE",
+        "sideBarSectionHeader.foreground": "#403C3A",
+
+        // Workbench: Status Bar
+        "statusBar.foreground": "#403C3A",
+        "statusBar.background": "#F6F6F6",
+        "statusBar.debuggingBackground": "#d3d0d0",
+        "statusBar.noFolderBackground": "#00616F",
+        "statusBarItem.prominentBackground": "#00616F",
+        "statusBarItem.prominentHoverBackground": "#DEDEDE22",
+        // "statusBarItem.activeBackground": "",
+        // "statusBarItem.hoverBackground": "",
+
+        // Workbench: Debug
+        "debugToolBar.background": "#FF9459",
+        "debugExceptionWidget.background": "#DEDEDE",
+        "debugExceptionWidget.border": "#FF793E",
+
+        // Workbench: Notifications
+        "notification.background": "#bebebe",
+        "notification.infoBackground": "#48b9c7",
+        "notification.infoForeground": "#ffffff",
+        "notification.buttonBackground": "#48b9c7",
+        "notification.warningBackground": "#bebebe",
+        "notification.foreground": "#383838",
+
+        // Workbench: Quick Open
+        "pickerGroup.border": "#2AA19899",
+        "pickerGroup.foreground": "#2AA19899",
+
+        // Extensions
+        "extensionButton.prominentBackground": "#faa41a",
+        "extensionButton.prominentHoverBackground": "#584c27aa",
+
+        // Workbench: Terminal
+
+        "terminal.ansiBlack": "#111",
+        "terminal.ansiRed": "#F15D22",
+        "terminal.ansiGreen": "#73C48F",
+        "terminal.ansiYellow": "#faa41a",
+        "terminal.ansiBlue": "#3F51B5",
+        "terminal.ansiMagenta": "#9C27B0",
+        "terminal.ansiCyan": "#48B9C7",
+        "terminal.ansiWhite": "#DEDEDE",
+        "terminal.ansiBrightBlack": "#574F4A",
+        "terminal.ansiBrightRed": "#cb4b16",
+        "terminal.ansiBrightGreen": "#574e4a",
+        "terminal.ansiBrightYellow": "#657b83",
+        "terminal.ansiBrightBlue": "#839496",
+        "terminal.ansiBrightMagenta": "#6c71c4",
+        "terminal.ansiBrightCyan": "#93a1a1",
+        "terminal.ansiBrightWhite": "#d3d0d0"
             },
 	"tokenColors": [
 		{

--- a/poptheme/themes/Pop-color-theme.json
+++ b/poptheme/themes/Pop-color-theme.json
@@ -1,0 +1,501 @@
+{
+    "name": "Pop",
+    "type": "light",
+    "colors": {
+                // Base
+                // "foreground": "",
+                "focusBorder": "#574F4A",
+                // "contrastActiveBorder": "",
+                // "contrastBorder": "",
+
+                // "widget.shadow": "",
+                "textLink.foreground": "#C26C00",
+                "textLink.activeForeground": "#DE8800",
+                "input.background": "#FFFFFF",
+                "input.border": "#0008",
+                "input.foreground": "#403C3A",
+                "input.placeholderForeground": "#403C3A88",
+                "inputOption.activeBorder": "#FAA41A",
+                // "inputValidation.infoBorder": "",
+                // "inputValidation.infoBackground": "",
+                // "inputValidation.warningBackground": "",
+                // "inputValidation.warningBorder": "",
+                // "inputValidation.errorBackground": "",
+                // "inputValidation.errorBorder": "",
+
+                "badge.background": "#F15D22",
+                "progressBar.background": "#48B9C7",
+
+                "dropdown.background": "#F6F6F6",
+                "dropdown.foreground": "#403C3A",
+                "dropdown.border": "#63524b00",
+
+                "button.background": "#F6F6F6",
+                // "button.foreground": "",
+
+                "selection.background": "#1C8D9B",
+
+                "list.activeSelectionBackground": "#574F4A33",
+                "list.activeSelectionForeground": "#403C3A",
+                "list.focusBackground": "#48B9C7",
+                "list.focusForeground": "#FCFCFC",
+                "list.hoverBackground": "#FCFCFC44",
+                "list.inactiveSelectionBackground": "#48B9C7AA",
+                "list.highlightForeground": "#FAA41A",
+
+                // "scrollbar.shadow": "",
+                // "scrollbarSlider.activeBackground": "",
+                // "scrollbarSlider.background": "",
+                // "scrollbarSlider.hoverBackground": "",
+
+                
+                
+                // Editor
+                "editor.background": "#FFF",
+                "editor.foreground": "#403C3A",
+                "editorWidget.background": "#2B2928",
+                "editorCursor.foreground": "#2B2928",
+                "editorWhitespace.foreground": "#DEDEDE11",
+                "editor.lineHighlightBackground": "#EDEDED",
+                "editor.selectionBackground": "#48B9C744",
+                // "editorIndentGuide.background": "",
+                "editorHoverWidget.background": "#F6F6F6",
+                // "editorHoverWidget.border": "",
+                "editorLineNumber.foreground": "#403C3A66",
+                "editorLineNumber.activeForeground": "#403C3A",
+                // "editorMarkerNavigation.background": "",
+                // "editorMarkerNavigationError.background": "",
+                // "editorMarkerNavigationWarning.background": "",
+                // "editorLink.activeForeground": "",
+                // "editor.findMatchBackground": "",
+                // "editor.findMatchHighlightBackground": "",
+                // "editor.findRangeHighlightBackground": "",
+                // "editor.hoverHighlightBackground": "",
+                // "editor.inactiveSelectionBackground": "",
+                // "editor.lineHighlightBorder": "",
+                // "editor.rangeHighlightBackground": "",
+                // "editor.selectionHighlightBackground": "",
+                // "editor.wordHighlightBackground": "",
+                // "editor.wordHighlightStrongBackground": "",
+
+                // Editor: Suggest Widget
+                // "editorSuggestWidget.background": "",
+                // "editorSuggestWidget.border": "",
+                // "editorSuggestWidget.foreground": "",
+                // "editorSuggestWidget.highlightForeground": "",
+                // "editorSuggestWidget.selectedBackground": "",
+
+                // Editor: Peek View
+                "peekViewResult.background": "#EDEDED",
+                // "peekViewResult.lineForeground": "",
+                // "peekViewResult.selectionBackground": "",
+                // "peekViewResult.selectionForeground": "",
+                "peekViewEditor.background": "#EDEDED",
+                "peekViewTitle.background": "#FCFCFC",
+                "peekView.border": "#FAA41A",
+                "peekViewEditor.matchHighlightBackground": "#FFCE5199",
+                // "peekViewResult.fileForeground": "",
+                // "peekViewResult.matchHighlightBackground": "",
+                // "peekViewTitleLabel.foreground": "",
+                // "peekViewTitleDescription.foreground": "",
+
+                // Editor: Diff
+                // "diffEditor.insertedTextBackground": "",
+                // "diffEditor.insertedTextBorder": "",
+                // "diffEditor.removedTextBackground": "",
+                // "diffEditor.removedTextBorder": "",
+
+                // Workbench: Title
+                "titleBar.activeBackground": "#574F4A",
+                "titleBar.activeForeground": "#F6F6F6",
+                "titleBar.inactiveBackground": "#655C56",
+                "titleBar.inactiveForeground": "#F6F6F699",
+
+                // Workbench: Editors
+                "editorGroupHeader.noTabsBackground": "#EDEDED",
+                "editorGroup.border": "#DEDEDE22",
+                "editorGroup.background": "#EDEDED",
+                "editorGroup.dropBackground": "#FAA41AAA",
+                "editorGroupHeader.tabsBackground": "#EDEDED",
+
+                // Workbench: Tabs
+                "tab.border": "#0000",
+                "tab.inactiveForeground": "#403C3A",
+                "tab.inactiveBackground": "#00000000",
+                "tab.activeForeground": "#C26C00",
+                "tab.activeBackground": "#0000",
+                "tab.activeBorder": "#FAA41A",
+
+                // Workbench: Activity Bar
+                "activityBar.background": "#DDD",
+                "activityBar.foreground": "#403C3A",
+                "activityBar.dropBackground": "#d3d0d0",
+                "activityBarBadge.background": "#CF3B00",
+                "activityBarBadge.foreground": "#FFF",
+
+                // Workbench: Panel
+                "panel.background": "#E6E6E6",
+                "panel.border": "#403C3A11",
+                // "panelTitle.activeBorder": "",
+                "panelTitle.activeForeground": "#C26C00",
+                "panelTitle.activeBorder": "#FAA41A",
+                "panelTitle.inactiveForeground": "#403C3A",
+
+                // Workbench: Side Bar
+                "sideBar.background": "#F6F6F6",
+                "sideBar.foreground":"#403C3A",
+                "sideBarTitle.foreground": "#403C3AAA",
+                "sideBarSectionHeader.background": "#DEDEDE",
+                "sideBarSectionHeader.foreground": "#403C3A",
+
+                // Workbench: Status Bar
+                "statusBar.foreground": "#403C3A",
+                "statusBar.background": "#F6F6F6",
+                "statusBar.debuggingBackground": "#d3d0d0",
+                "statusBar.noFolderBackground": "#00616F",
+                "statusBarItem.prominentBackground": "#00616F",
+                "statusBarItem.prominentHoverBackground": "#DEDEDE22",
+                // "statusBarItem.activeBackground": "",
+                // "statusBarItem.hoverBackground": "",
+
+                // Workbench: Debug
+                "debugToolBar.background": "#FF9459",
+                "debugExceptionWidget.background": "#DEDEDE",
+                "debugExceptionWidget.border": "#FF793E",
+
+                // Workbench: Notifications
+                "notification.background": "#bebebe",
+                "notification.infoBackground": "#48b9c7",
+                "notification.infoForeground": "#ffffff",
+                "notification.buttonBackground": "#48b9c7",
+                "notification.warningBackground": "#bebebe",
+                "notification.foreground": "#383838",
+
+                // Workbench: Quick Open
+                "pickerGroup.border": "#2AA19899",
+                "pickerGroup.foreground": "#2AA19899",
+
+                // Extensions
+                "extensionButton.prominentBackground": "#faa41a",
+                "extensionButton.prominentHoverBackground": "#584c27aa",
+
+                // Workbench: Terminal
+
+                "terminal.ansiBlack": "#111",
+                "terminal.ansiRed": "#F15D22",
+                "terminal.ansiGreen": "#73C48F",
+                "terminal.ansiYellow": "#faa41a",
+                "terminal.ansiBlue": "#3F51B5",
+                "terminal.ansiMagenta": "#9C27B0",
+                "terminal.ansiCyan": "#48B9C7",
+                "terminal.ansiWhite": "#DEDEDE",
+                "terminal.ansiBrightBlack": "#574F4A",
+                "terminal.ansiBrightRed": "#cb4b16",
+                "terminal.ansiBrightGreen": "#574e4a",
+                "terminal.ansiBrightYellow": "#657b83",
+                "terminal.ansiBrightBlue": "#839496",
+                "terminal.ansiBrightMagenta": "#6c71c4",
+                "terminal.ansiBrightCyan": "#93a1a1",
+                "terminal.ansiBrightWhite": "#d3d0d0"
+            },
+	"tokenColors": [
+		{
+			"settings": {
+				"background": "#d3d0d0",
+				"foreground": "#657B83"
+			}
+		},
+		{
+			"scope": ["meta.embedded", "source.groovy.embedded"],
+			"settings": {
+				"background": "#d3d0d0",
+				"foreground": "#657B83"
+			}
+		},
+		{
+			"name": "Comment",
+			"scope": "comment",
+			"settings": {
+				"fontStyle": "italic",
+				"foreground": "#93A1A1"
+			}
+		},
+		{
+			"name": "String",
+			"scope": "string",
+			"settings": {
+				"foreground": "#175541"
+			}
+		},
+		{
+			"name": "Regexp",
+			"scope": "string.regexp",
+			"settings": {
+				"foreground": "#f15d22"
+			}
+		},
+		{
+			"name": "Number",
+			"scope": "constant.numeric",
+			"settings": {
+				"foreground": "#f15d22"
+			}
+		},
+		{
+			"name": "Variable",
+			"scope": [
+				"variable.language",
+				"variable.other"
+			],
+			"settings": {
+				"foreground": "#3d5d6b"
+			}
+		},
+		{
+			"name": "Keyword",
+			"scope": "keyword",
+			"settings": {
+				"foreground": "#b94c4c"
+			}
+		},
+		{
+			"name": "Storage",
+			"scope": "storage",
+			"settings": {
+				"foreground": "#073642"
+			}
+		},
+		{
+			"name": "Class name",
+			"scope": [
+				"entity.name.class",
+				"entity.name.type"
+			],
+			"settings": {
+				"foreground": "#607D8B"
+			}
+		},
+		{
+			"name": "Functions",
+			"scope": [
+				"entity.name.function",
+				"support.function"
+			],
+			"settings": {
+				"foreground": "#5e4825"
+			}
+		},
+		{
+			"name": "Variable start",
+			"scope": "punctuation.definition.variable",
+			"settings": {
+				"foreground": "#34a357"
+			}
+		},
+		{
+			"name": "Embedded code markers",
+			"scope": [
+				"punctuation.section.embedded.begin",
+				"punctuation.section.embedded.end"
+			],
+			"settings": {
+				"foreground": "#f15d22"
+			}
+		},
+		{
+			"name": "Built-in constant",
+			"scope": [
+				"constant.language",
+				"meta.preprocessor"
+			],
+			"settings": {
+				"foreground": "#d37f00"
+			}
+		},
+		{
+			"name": "Support.construct",
+			"scope": [
+				"support.function.construct",
+				"keyword.other.new"
+			],
+			"settings": {
+				"foreground": "#f15d22"
+			}
+		},
+		{
+			"name": "User-defined constant",
+			"scope": [
+				"constant.character",
+				"constant.other"
+			],
+			"settings": {
+				"foreground": "#CB4B16"
+			}
+		},
+		{
+			"name": "Inherited class",
+			"scope": "entity.other.inherited-class",
+			"settings": {}
+		},
+		{
+			"name": "Function argument",
+			"scope": "variable.parameter",
+			"settings": {}
+		},
+		{
+			"name": "Tag name",
+			"scope": "entity.name.tag",
+			"settings": {
+				"foreground": "#607D8B"
+			}
+		},
+		{
+			"name": "Tag start/end",
+			"scope": [
+				"punctuation.definition.tag.begin",
+				"punctuation.definition.tag.end"
+			],
+			"settings": {
+				"foreground": "#376161"
+			}
+		},
+		{
+			"name": "Tag attribute",
+			"scope": "entity.other.attribute-name",
+			"settings": {
+				"foreground": "#439b9b"
+			}
+		},
+		{
+			"name": "Library function",
+			"scope": "support.function",
+			"settings": {
+				"foreground": "#376161"
+			}
+		},
+		{
+			"name": "Continuation",
+			"scope": "punctuation.separator.continuation",
+			"settings": {
+				"foreground": "#f15d22"
+			}
+		},
+		{
+			"name": "Library constant",
+			"scope": "support.constant",
+			"settings": {}
+		},
+		{
+			"name": "Library class/type",
+			"scope": [
+				"support.type",
+				"support.class"
+			],
+			"settings": {
+				"foreground": "#6e8b34"
+			}
+		},
+		{
+			"name": "Library Exception",
+			"scope": "support.type.exception",
+			"settings": {
+				"foreground": "#CB4B16"
+			}
+		},
+		{
+			"name": "Library variable",
+			"scope": "support.other.variable",
+			"settings": {}
+		},
+		{
+			"name": "Invalid",
+			"scope": "invalid",
+			"settings": {}
+		},
+		{
+			"name": "diff: header",
+			"scope": [
+				"meta.diff",
+				"meta.diff.header"
+			],
+			"settings": {
+				"background": "#faa41a",
+				"fontStyle": "italic",
+				"foreground": "#E0EDDD"
+			}
+		},
+		{
+			"name": "diff: deleted",
+			"scope": "markup.deleted",
+			"settings": {
+				"background": "#d3d0d0",
+				"fontStyle": "",
+				"foreground": "#f15d22"
+			}
+		},
+		{
+			"name": "diff: changed",
+			"scope": "markup.changed",
+			"settings": {
+				"background": "#d3d0d0",
+				"fontStyle": "",
+				"foreground": "#cb4b16"
+			}
+		},
+		{
+			"name": "diff: inserted",
+			"scope": "markup.inserted",
+			"settings": {
+				"background": "#d3d0d0",
+				"foreground": "#219186"
+			}
+		},
+		{
+			"name": "Markup Quote",
+			"scope": "markup.quote",
+			"settings": {
+				"foreground": "#488d5e"
+			}
+		},
+		{
+			"name": "Markup Lists",
+			"scope": "markup.list",
+			"settings": {
+				"foreground": "#faa41a"
+			}
+		},
+		{
+			"name": "Markup Styling",
+			"scope": [
+				"markup.bold",
+				"markup.italic"
+			],
+			"settings": {
+				"foreground": "#f15d22"
+			}
+		},
+		{
+			"name": "Markup Inline",
+			"scope": "markup.inline.raw",
+			"settings": {
+				"fontStyle": "",
+				"foreground": "#2AA198"
+			}
+		},
+		{
+			"name": "Markup Headings",
+			"scope": "markup.heading",
+			"settings": {
+				"foreground": "#607D8B"
+			}
+		},
+		{
+			"name": "Markup Setext Header",
+			"scope": "markup.heading.setext",
+			"settings": {
+				"fontStyle": "",
+				"foreground": "#607D8B"
+			}
+		}
+	]
+}

--- a/poptheme/themes/Pop-color-theme.json
+++ b/poptheme/themes/Pop-color-theme.json
@@ -25,7 +25,6 @@
 
                 "badge.background": "#F15D22",
                 "badge.foreground": "#FFF",
-                bad
                 "progressBar.background": "#48B9C7",
 
                 "dropdown.background": "#F6F6F6",

--- a/poptheme/themes/Pop-color-theme.json
+++ b/poptheme/themes/Pop-color-theme.json
@@ -24,6 +24,8 @@
                 // "inputValidation.errorBorder": "",
 
                 "badge.background": "#F15D22",
+                "badge.foreground": "#FFF",
+                bad
                 "progressBar.background": "#48B9C7",
 
                 "dropdown.background": "#F6F6F6",
@@ -53,7 +55,7 @@
                 // Editor
                 "editor.background": "#FFF",
                 "editor.foreground": "#403C3A",
-                "editorWidget.background": "#2B2928",
+                "editorWidget.background": "#DEDEDE",
                 "editorCursor.foreground": "#2B2928",
                 "editorWhitespace.foreground": "#DEDEDE11",
                 "editor.lineHighlightBackground": "#EDEDED",


### PR DESCRIPTION
The existing light theme doesn't quite match the actual
Pop theme. This PR should help them match much more
closely. Based on the Dark theme, but re-popified.

It also creates a Pop Theme, and separates the -Light
variant out into its own theme. This version has the light
titlebar, while the standard Pop theme uses the brand
warm grey for the titlebar.